### PR TITLE
fix(import): sanitize targets to prevent double-escaping in .strings

### DIFF
--- a/lib/xlocalize/importer.rb
+++ b/lib/xlocalize/importer.rb
@@ -1,11 +1,23 @@
-
 module Xlocalize
   class Importer
+
+    private
+    def sanitize_target_value(value)
+      # Convert common escaped sequences to raw characters first
+      # Ensure any number of backslashes before a quote becomes a raw quote
+      # Collapse any runs of backslashes to a single backslash
+      value
+        .gsub('\\n', "\n")
+        .gsub(/\\+\"/, '"')
+        .gsub(/\\{2,}/, '\\')
+    end
+    public
 
     def strings_content_from_translations_hash(translations_hash)
       result = StringIO.new
       translations_hash.each do |key, translations|
         translations.each do |target, note|
+          target = sanitize_target_value(target)
           result << "/* #{note} */\n" if note.length > 0
           result << "\"#{key}\" = #{target.inspect};\n\n"
         end
@@ -17,7 +29,8 @@ module Xlocalize
       (node > "body > trans-unit").each do |trans_unit|
         key = trans_unit["id"]
         target = (trans_unit > "target").text
-        note = (trans_unit > "note").text
+        target = target.gsub('\\"', '"').gsub('\\\\n', "\n")
+        note = (trans_unit > "note").text || ""
         if translations.key?(key)
           translations[key] = { target => note }
         end

--- a/lib/xlocalize/version.rb
+++ b/lib/xlocalize/version.rb
@@ -1,4 +1,4 @@
 module Xlocalize
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
   DESCRIPTION = "Xcode localizations import/export helper tool"
 end


### PR DESCRIPTION
Ensures imported values are unescaped and normalized before serializing with Ruby inspect, preventing runaway backslashes on repeated imports. Idempotent across re-runs.

bump version