### PR TITLE
Fix XLIFF namespace compatibility and add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec
+
+      - name: Build gem
+        run: gem build xlocalize.gemspec

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
+*.xcloc/
 
 # iOS specific ignores, used in sample projects inside the repo
 *.pbxuser

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-[![Build Status](https://travis-ci.org/viktorasl/xlocalize.svg?branch=master)](https://travis-ci.org/viktorasl/xlocalize)
+[![CI](https://github.com/treatwell/xlocalize/actions/workflows/ci.yml/badge.svg)](https://github.com/treatwell/xlocalize/actions/workflows/ci.yml)
 [![Gem Version](https://badge.fury.io/rb/xlocalize.svg)](https://badge.fury.io/rb/xlocalize)
-[![Code Climate](https://codeclimate.com/github/viktorasl/xlocalize/badges/gpa.svg)](https://codeclimate.com/github/viktorasl/xlocalize)
-[![Test Coverage](https://codeclimate.com/github/viktorasl/xlocalize/badges/coverage.svg)](https://codeclimate.com/github/viktorasl/xlocalize/coverage)
-[![Inline docs](http://inch-ci.org/github/viktorasl/xlocalize.svg?branch=master)](http://inch-ci.org/github/viktorasl/xlocalize)
 
 # Xlocalize
 

--- a/lib/xlocalize/executor.rb
+++ b/lib/xlocalize/executor.rb
@@ -91,7 +91,7 @@ module Xlocalize
       puts "Filtering plurals" if $VERBOSE
       plurals = doc.filter_plurals(project)
       puts "Removing excluded translation units" if $VERBOSE
-      doc.xpath("//xmlns:trans-unit").each { |unit| unit.remove if exclude_units.include?(unit['id']) }
+      doc.xliff_xpath("//xmlns:trans-unit").each { |unit| unit.remove if exclude_units.include?(unit['id']) }
       puts "Removing all files having no trans-unit elements after removal" if $VERBOSE
       doc.filter_empty_files
       puts "Unescaping translation units" if $VERBOSE
@@ -170,7 +170,8 @@ module Xlocalize
 
     def import_xliff(fname)
       puts "Importing translations from #{fname}" if $VERBOSE
-      Nokogiri::XML(File.open(fname)).xpath("//xmlns:file").each do |node|
+      doc = Nokogiri::XML(File.open(fname))
+      doc.xliff_xpath("//xmlns:file").each do |node|
         tr_fname = node["original"]
         source_lang = node["source-language"]
         target_lang = node["target-language"]


### PR DESCRIPTION
XLIFF files from Lokalise/WTI lack the default XML namespace (xmlns="..."), using only schemaLocation instead. This caused Nokogiri XPath queries like //xmlns:file to fail with "Undefined namespace prefix".

Add xliff_xpath helper that detects whether the document has a default namespace and adapts the XPath accordingly, supporting both old (Xcode-generated) and new (Lokalise) XLIFF formats.

Also:
- Add GitHub Actions CI workflow (replaces defunct Travis CI)
- Fix export tests for Xcode >= 10 (.xcloc path)
- Update README badges to point to treatwell/xlocalize
- Add vendor/ and *.xcloc/ to .gitignore